### PR TITLE
Fix paging docs

### DIFF
--- a/source/includes/2016-03-05/_disputes.md
+++ b/source/includes/2016-03-05/_disputes.md
@@ -338,8 +338,8 @@ This endpoint will list all the disputes that we have synced from your payment p
 | Parameter      | Type       | Required?  | Description                                                          |
 | -------------  | ---------- | ---------- | -------------------------------------------------------------------- |
 | limit          | integer    | optional   | Maximum number of disputes to return. Default is 20, maximum is 100. |
-| starting_after | string     | optional   | A dispute id. Fetch disputes created after this dispute.             |
-| ending_before  | string     | optional   | A dispute id. Fetch disputes created before this dispute.            |
+| starting_after | string     | optional   | A dispute id. Fetch the next page of disputes (disputes created before this dispute). |
+| ending_before  | string     | optional   | A dispute id. Fetch the previous page of disputes (disputes created after this dispute). |
 | state          | string     | optional   | Dispute state. Will only fetch disputes with the state.            |
 
 ## Retrieving a dispute

--- a/source/includes/_disputes.md
+++ b/source/includes/_disputes.md
@@ -336,8 +336,8 @@ This endpoint will list all the disputes that we have synced from your payment p
 | Parameter      | Type       | Required?  | Description                                                          |
 | -------------  | ---------- | ---------- | -------------------------------------------------------------------- |
 | limit          | integer    | optional   | Maximum number of disputes to return. Default is 20, maximum is 100. |
-| starting_after | string     | optional   | A dispute id. Fetch disputes created after this dispute.             |
-| ending_before  | string     | optional   | A dispute id. Fetch disputes created before this dispute.            |
+| starting_after | string     | optional   | A dispute id. Fetch the next page of disputes (disputes created before this dispute). |
+| ending_before  | string     | optional   | A dispute id. Fetch the previous page of disputes (disputes created after this dispute). |
 | state          | string     | optional   | Dispute state. Will only fetch disputes with the state.            |
 
 ## Retrieving a dispute


### PR DESCRIPTION
Fix backwards documentation of paging parameters. The disputes are ordered by created with the most recent dispute first, this is already mentioned in the docs.