### PR TITLE
Multiple states

### DIFF
--- a/source/includes/2016-03-05/_disputes.md
+++ b/source/includes/2016-03-05/_disputes.md
@@ -376,7 +376,7 @@ This endpoint will list all the disputes that we have synced from your payment p
 | limit          | integer    | optional   | Maximum number of disputes to return. Default is 20, maximum is 100. |
 | starting_after | string     | optional   | A dispute id. Fetch the next page of disputes (disputes created before this dispute). |
 | ending_before  | string     | optional   | A dispute id. Fetch the previous page of disputes (disputes created after this dispute). |
-| state          | string     | optional   | Dispute state. Will only fetch disputes with the state.            |
+| state          | string     | optional   | Dispute state. Will only fetch disputes with the state. Multiple states can be provided. |
 | account        | string     | optional   | Account id. Will only fetch disputes under that connected account. View your connected accounts in the Chargehound dashboard settings page [here](/dashboard/settings/processors). |
 
 ## Retrieving a dispute
@@ -1161,6 +1161,67 @@ chargehound.disputes.submit("dp_123",
 ```
 
 In order to submit a Braintree dispute, you will also need to attach the Braintree transaction id using the `charge` parameter. 
+
+## Stripe listing needs response
+
+> Example usage:
+
+```sh
+curl https://api.chargehound.com/v1/disputes?needs_response&warning_needs_response \
+  -u test_123:
+```
+
+```javascript
+var chargehound = require('chargehound')(
+  'test_123'
+);
+
+chargehound.Disputes.list({state: ['needs_response', 'warning_needs_response']}, function (err, res) {
+  // ...
+});
+```
+
+```python
+import chargehound
+chargehound.api_key = 'test_123'
+
+chargehound.Disputes.list(state=['needs_response', 'warning_needs_response'])
+```
+
+```ruby
+require 'chargehound'
+Chargehound.api_key = 'test_123'
+
+Chargehound::Disputes.list(state: %w[needs_response warning_needs_response])
+```
+
+```go
+import (
+  "github.com/chargehound/chargehound-go"
+)
+
+ch := chargehound.New("test_123", nil)
+
+disputeList, err := ch.Disputes.List(&chargehound.ListDisputesParams{
+    State: []string{
+      "needs_response",
+      "warning_needs_response",
+    },
+  })
+```
+
+```java
+import com.chargehound.Chargehound;
+import com.chargehound.models.DisputesList;
+
+Chargehound chargehound = new Chargehound("test_123");
+
+DisputesList.Params params = new DisputesList.Params.Builder()
+    .state("needs_response", "warning_needs_response")
+    .finish();
+
+DisputesList result = chargehound.disputes.list(params);
+```
 
 ## Stripe charging directly
 

--- a/source/includes/2016-03-05/_disputes.md
+++ b/source/includes/2016-03-05/_disputes.md
@@ -376,7 +376,7 @@ This endpoint will list all the disputes that we have synced from your payment p
 | limit          | integer    | optional   | Maximum number of disputes to return. Default is 20, maximum is 100. |
 | starting_after | string     | optional   | A dispute id. Fetch the next page of disputes (disputes created before this dispute). |
 | ending_before  | string     | optional   | A dispute id. Fetch the previous page of disputes (disputes created after this dispute). |
-| state          | string     | optional   | Dispute state. Will only fetch disputes with the state. Multiple states can be provided. |
+| state          | string     | optional   | Dispute state. Filter the disputes by state. Multiple `state` parameters can be provided to expand the filter to multiple states. |
 | account        | string     | optional   | Account id. Will only fetch disputes under that connected account. View your connected accounts in the Chargehound dashboard settings page [here](/dashboard/settings/processors). |
 
 ## Retrieving a dispute

--- a/source/includes/2016-03-05/_disputes.md
+++ b/source/includes/2016-03-05/_disputes.md
@@ -268,7 +268,7 @@ chargehound.disputes.list();
 > Example request:
 
 ```sh
-curl https://api.chargehound.com/v1/disputes \
+curl https://api.chargehound.com/v1/disputes?state=warning_needs_response&state=needs_response \
   -u test_123:
 ```
 
@@ -277,7 +277,7 @@ var chargehound = require('chargehound')(
   'test_123'
 );
 
-chargehound.Disputes.list(null, function (err, res) {
+chargehound.Disputes.list({state: ['warning_needs_response', 'needs_response']}, function (err, res) {
   // ...
 });
 ```
@@ -286,14 +286,14 @@ chargehound.Disputes.list(null, function (err, res) {
 import chargehound
 chargehound.api_key = 'test_123'
 
-chargehound.Disputes.list()
+chargehound.Disputes.list(state=['warning_needs_response', 'needs_response'])
 ```
 
 ```ruby
 require 'chargehound'
 Chargehound.api_key = 'test_123'
 
-Chargehound::Disputes.list
+Chargehound::Disputes.list(state: %w[warning_needs_response needs_response])
 ```
 
 ```go
@@ -303,15 +303,25 @@ import (
 
 ch := chargehound.New("test_123", nil)
 
-disputeList, err := ch.Disputes.List(nil)
+disputeList, err := ch.Disputes.List(&chargehound.ListDisputesParams{
+    State: []string{
+      "warning_needs_response",
+      "needs_response",
+    },
+  })
 ```
 
 ```java
 import com.chargehound.Chargehound;
+import com.chargehound.models.DisputesList;
 
 Chargehound chargehound = new Chargehound("test_123");
 
-chargehound.disputes.list();
+DisputesList.Params params = new DisputesList.Params.Builder()
+    .state("warning_needs_response", "needs_response")
+    .finish();
+
+DisputesList result = chargehound.disputes.list(params);
 ```
 
 > Example response:
@@ -1161,67 +1171,6 @@ chargehound.disputes.submit("dp_123",
 ```
 
 In order to submit a Braintree dispute, you will also need to attach the Braintree transaction id using the `charge` parameter. 
-
-## Stripe listing needs response
-
-> Example usage:
-
-```sh
-curl https://api.chargehound.com/v1/disputes?needs_response&warning_needs_response \
-  -u test_123:
-```
-
-```javascript
-var chargehound = require('chargehound')(
-  'test_123'
-);
-
-chargehound.Disputes.list({state: ['needs_response', 'warning_needs_response']}, function (err, res) {
-  // ...
-});
-```
-
-```python
-import chargehound
-chargehound.api_key = 'test_123'
-
-chargehound.Disputes.list(state=['needs_response', 'warning_needs_response'])
-```
-
-```ruby
-require 'chargehound'
-Chargehound.api_key = 'test_123'
-
-Chargehound::Disputes.list(state: %w[needs_response warning_needs_response])
-```
-
-```go
-import (
-  "github.com/chargehound/chargehound-go"
-)
-
-ch := chargehound.New("test_123", nil)
-
-disputeList, err := ch.Disputes.List(&chargehound.ListDisputesParams{
-    State: []string{
-      "needs_response",
-      "warning_needs_response",
-    },
-  })
-```
-
-```java
-import com.chargehound.Chargehound;
-import com.chargehound.models.DisputesList;
-
-Chargehound chargehound = new Chargehound("test_123");
-
-DisputesList.Params params = new DisputesList.Params.Builder()
-    .state("needs_response", "warning_needs_response")
-    .finish();
-
-DisputesList result = chargehound.disputes.list(params);
-```
 
 ## Stripe charging directly
 

--- a/source/includes/_disputes.md
+++ b/source/includes/_disputes.md
@@ -373,7 +373,7 @@ This endpoint will list all the disputes that we have synced from your payment p
 | limit          | integer    | optional   | Maximum number of disputes to return. Default is 20, maximum is 100.                     |
 | starting_after | string     | optional   | A dispute id. Fetch the next page of disputes (disputes created before this dispute).    |
 | ending_before  | string     | optional   | A dispute id. Fetch the previous page of disputes (disputes created after this dispute). |
-| state          | string     | optional   | Dispute state. Will only fetch disputes with the state.                                  |
+| state          | string     | optional   | Dispute state. Will only fetch disputes with the state. Multiple states can be provided. |
 | account        | string     | optional   | Account id. Will only fetch disputes under that connected account. View your connected accounts in the Chargehound dashboard settings page [here](/dashboard/settings/processors). |
 
 ## Retrieving a dispute
@@ -1159,6 +1159,69 @@ If Chargehound does not have access to the Braintree disputes API, you'll need t
 You will also need to attach the Braintree transaction id using the `charge` parameter when updating or submitting disputes using the Chargehound API.
 
 You can always reconnect your Braintree account from the settings page [here](/dashboard/settings/processors) to grant Chargehound access to the disputes API, this will make your integration easier.
+
+## Stripe listing needs response
+
+> Example usage:
+
+```sh
+curl https://api.chargehound.com/v1/disputes?needs_response&warning_needs_response \
+  -u test_123:
+```
+
+```javascript
+var chargehound = require('chargehound')(
+  'test_123'
+);
+
+chargehound.Disputes.list({state: ['needs_response', 'warning_needs_response']}, function (err, res) {
+  // ...
+});
+```
+
+```python
+import chargehound
+chargehound.api_key = 'test_123'
+
+chargehound.Disputes.list(state=['needs_response', 'warning_needs_response'])
+```
+
+```ruby
+require 'chargehound'
+Chargehound.api_key = 'test_123'
+
+Chargehound::Disputes.list(state: %w[needs_response warning_needs_response])
+```
+
+```go
+import (
+  "github.com/chargehound/chargehound-go"
+)
+
+ch := chargehound.New("test_123", nil)
+
+disputeList, err := ch.Disputes.List(&chargehound.ListDisputesParams{
+    State: []string{
+      "needs_response",
+      "warning_needs_response",
+    },
+  })
+```
+
+```java
+import com.chargehound.Chargehound;
+import com.chargehound.models.DisputesList;
+
+Chargehound chargehound = new Chargehound("test_123");
+
+DisputesList.Params params = new DisputesList.Params.Builder()
+    .state("needs_response", "warning_needs_response")
+    .finish();
+
+DisputesList result = chargehound.disputes.list(params);
+```
+
+Stripe retrievals are initially in `warning_needs_response`, so to list all disputes needing response for a Stripe accounts it's necessary to filter by both `needs_response` and `warning_needs_response`.
 
 ## Stripe charging directly
 

--- a/source/includes/_disputes.md
+++ b/source/includes/_disputes.md
@@ -373,7 +373,7 @@ This endpoint will list all the disputes that we have synced from your payment p
 | limit          | integer    | optional   | Maximum number of disputes to return. Default is 20, maximum is 100.                     |
 | starting_after | string     | optional   | A dispute id. Fetch the next page of disputes (disputes created before this dispute).    |
 | ending_before  | string     | optional   | A dispute id. Fetch the previous page of disputes (disputes created after this dispute). |
-| state          | string     | optional   | Dispute state. Will only fetch disputes with the state. Multiple states can be provided. |
+| state          | string     | optional   | Dispute state. Filter the disputes by state. Multiple `state` parameters can be provided to expand the filter to multiple states. |
 | account        | string     | optional   | Account id. Will only fetch disputes under that connected account. View your connected accounts in the Chargehound dashboard settings page [here](/dashboard/settings/processors). |
 
 ## Retrieving a dispute

--- a/source/includes/_disputes.md
+++ b/source/includes/_disputes.md
@@ -264,7 +264,7 @@ chargehound.disputes.list();
 > Example request:
 
 ```sh
-curl https://api.chargehound.com/v1/disputes \
+curl https://api.chargehound.com/v1/disputes?state=warning_needs_response&state=needs_response \
   -u test_123:
 ```
 
@@ -273,7 +273,7 @@ var chargehound = require('chargehound')(
   'test_123'
 );
 
-chargehound.Disputes.list(null, function (err, res) {
+chargehound.Disputes.list({state: ['warning_needs_response', 'needs_response']}, function (err, res) {
   // ...
 });
 ```
@@ -282,14 +282,14 @@ chargehound.Disputes.list(null, function (err, res) {
 import chargehound
 chargehound.api_key = 'test_123'
 
-chargehound.Disputes.list()
+chargehound.Disputes.list(state=['warning_needs_response', 'needs_response'])
 ```
 
 ```ruby
 require 'chargehound'
 Chargehound.api_key = 'test_123'
 
-Chargehound::Disputes.list
+Chargehound::Disputes.list(state: %w[warning_needs_response needs_response])
 ```
 
 ```go
@@ -299,15 +299,25 @@ import (
 
 ch := chargehound.New("test_123", nil)
 
-disputeList, err := ch.Disputes.List(nil)
+disputeList, err := ch.Disputes.List(&chargehound.ListDisputesParams{
+    State: []string{
+      "warning_needs_response",
+      "needs_response",
+    },
+  })
 ```
 
 ```java
 import com.chargehound.Chargehound;
+import com.chargehound.models.DisputesList;
 
 Chargehound chargehound = new Chargehound("test_123");
 
-chargehound.disputes.list();
+DisputesList.Params params = new DisputesList.Params.Builder()
+    .state("warning_needs_response", "needs_response")
+    .finish();
+
+DisputesList result = chargehound.disputes.list(params);
 ```
 
 > Example response:
@@ -1159,69 +1169,6 @@ If Chargehound does not have access to the Braintree disputes API, you'll need t
 You will also need to attach the Braintree transaction id using the `charge` parameter when updating or submitting disputes using the Chargehound API.
 
 You can always reconnect your Braintree account from the settings page [here](/dashboard/settings/processors) to grant Chargehound access to the disputes API, this will make your integration easier.
-
-## Stripe listing needs response
-
-> Example usage:
-
-```sh
-curl https://api.chargehound.com/v1/disputes?needs_response&warning_needs_response \
-  -u test_123:
-```
-
-```javascript
-var chargehound = require('chargehound')(
-  'test_123'
-);
-
-chargehound.Disputes.list({state: ['needs_response', 'warning_needs_response']}, function (err, res) {
-  // ...
-});
-```
-
-```python
-import chargehound
-chargehound.api_key = 'test_123'
-
-chargehound.Disputes.list(state=['needs_response', 'warning_needs_response'])
-```
-
-```ruby
-require 'chargehound'
-Chargehound.api_key = 'test_123'
-
-Chargehound::Disputes.list(state: %w[needs_response warning_needs_response])
-```
-
-```go
-import (
-  "github.com/chargehound/chargehound-go"
-)
-
-ch := chargehound.New("test_123", nil)
-
-disputeList, err := ch.Disputes.List(&chargehound.ListDisputesParams{
-    State: []string{
-      "needs_response",
-      "warning_needs_response",
-    },
-  })
-```
-
-```java
-import com.chargehound.Chargehound;
-import com.chargehound.models.DisputesList;
-
-Chargehound chargehound = new Chargehound("test_123");
-
-DisputesList.Params params = new DisputesList.Params.Builder()
-    .state("needs_response", "warning_needs_response")
-    .finish();
-
-DisputesList result = chargehound.disputes.list(params);
-```
-
-Stripe retrievals are initially in `warning_needs_response`, so to list all disputes needing response for a Stripe accounts it's necessary to filter by both `needs_response` and `warning_needs_response`.
 
 ## Stripe charging directly
 

--- a/source/includes/_integration.md
+++ b/source/includes/_integration.md
@@ -526,7 +526,7 @@ Because Chargehound creates live mode disputes with [webhooks](https://developer
 Before integrating with Chargehound you might have accrued a dispute backlog, but you can easily respond to all of those disputes by writing a simple script and running it as the final integration step.
 
 ```sh
-curl https://api.chargehound.com/v1/disputes?state=needs_response \
+curl https://api.chargehound.com/v1/disputes?state=warning_needs_response&state=needs_response \
   -u test_123
 ```
 
@@ -536,7 +536,7 @@ var chargehound = require('chargehound')(
 );
 
 async function respondToBacklog () {
-  var res = await chargehound.Disputes.list({state: 'needs_response'});
+  var res = await chargehound.Disputes.list({state: ['warning_needs_response', 'needs_response']});
   await Promise.all(res.data.map(async function (dispute) {
     // Submit the dispute.
   });
@@ -553,7 +553,7 @@ import chargehound
 chargehound.api_key = 'test_123'
 
 def respond_to_backlog():
-  res = chargehound.Disputes.list(state='needs_response')
+  res = chargehound.Disputes.list(state=['warning_needs_response', 'needs_response'])
   for dispute in res['data']:
     # Submit the dispute.
 
@@ -567,7 +567,7 @@ require 'chargehound'
 Chargehound.api_key = 'test_123'
 
 def respond_to_backlog()
-  res = Chargehound::Disputes.list(state: 'needs_response')
+  res = Chargehound::Disputes.list(state: %w[needs_response warning_needs_response])
   res['data'].each { |dispute|
     # Submit the dispute.
   }
@@ -588,7 +588,7 @@ ch := chargehound.New("test_123", nil)
 
 func respondToBacklog () {
   params := chargehound.ListDisputesParams{
-    State: "needs_response",
+    State: []string{"warning_needs_response", "needs_response"},
   }
 
   response, err := ch.Disputes.List(&params)
@@ -614,7 +614,7 @@ Chargehound chargehound = new Chargehound("${apiKey}");
 public void respondToBacklog() {
   DisputesList result = chargehound.Disputes.list(
     new DisputesList.Params.Builder()
-      .state("needs_response")
+      .state("warning_needs_response", "needs_response")
       .finish()
   );
 


### PR DESCRIPTION
Add an example of listing disputes with multiple states; call out Stripe as being a special case that needs this.

Note that: "Multiple `state` parameters can be provided to expand the filter to multiple states."