### PR TITLE
Amex

### DIFF
--- a/source/includes/2016-03-05/_disputes.md
+++ b/source/includes/2016-03-05/_disputes.md
@@ -42,8 +42,8 @@ A dispute object is:
 | account_id           | string     | The account id for Connected accounts that are charged directly through Stripe (if any). (See [Stripe charging directly](#stripe-charging-directly) for details.) |
 | created              | string     | ISO 8601 timestamp - when the dispute was created in Chargehound. |
 | updated              | string     | ISO 8601 timestamp - when the dispute was last updated in Chargehound. |
-| source               | string     | The source of the dispute. One of `mock`, `api`, `braintree`, `vantiv`, `adyen`, `worldpay` or `stripe` |
-| processor            | string     | The payment processor of the dispute. One of `braintree`, `vantiv`, `adyen`, `worldpay` or `stripe` |
+| source               | string     | The source of the dispute. One of `mock`, `api`, `braintree`, `vantiv`, `adyen`, `worldpay`, `paypal`, `amex` or `stripe` |
+| processor            | string     | The payment processor of the dispute. One of `braintree`, `vantiv`, `adyen`, `worldpay`, `paypal`, `amex` or `stripe`     |
 | kind                 | string     | The kind of the dispute. One of `chargeback`, `pre_arbitration` or `retrieval` |
 | reference_url        | string     | Custom URL with dispute information, such as the dispute or charge in your company dashboard. |
 

--- a/source/includes/2017-10-30/_disputes.md
+++ b/source/includes/2017-10-30/_disputes.md
@@ -42,8 +42,8 @@ A dispute object is:
 | account_id           | string     | The account id for accounts that are charged directly through Stripe (if any). (See [Stripe charging directly](#stripe-charging-directly) for details.) |
 | created              | string     | ISO 8601 timestamp - when the dispute was created in Chargehound.                                       |
 | updated              | string     | ISO 8601 timestamp - when the dispute was last updated in Chargehound.                                  |
-| source               | string     | The source of the dispute. One of `mock`, `api`, `braintree`, `vantiv`, `adyen`, `worldpay` or `stripe` |
-| processor            | string     | The payment processor of the dispute. One of `braintree`, `vantiv`, `adyen`, `worldpay` or `stripe`     |
+| source               | string     | The source of the dispute. One of `mock`, `api`, `braintree`, `vantiv`, `adyen`, `worldpay`, `paypal`, `amex` or `stripe` |
+| processor            | string     | The payment processor of the dispute. One of `braintree`, `vantiv`, `adyen`, `worldpay`, `paypal`, `amex` or `stripe`     |
 | kind                 | string     | The kind of the dispute. One of `chargeback`, `pre_arbitration` or `retrieval`                          |
 | account              | string     | The Id of the connected account for this dispute.                                                       |
 | reference_url        | string     | Custom URL with dispute information, such as the dispute or charge in your company dashboard.           |

--- a/source/includes/_disputes.md
+++ b/source/includes/_disputes.md
@@ -42,8 +42,8 @@ A dispute object is:
 | account_id           | string     | The account id for accounts that are charged directly through Stripe (if any). (See [Stripe charging directly](#stripe-charging-directly) for details.) |
 | created              | string     | ISO 8601 timestamp - when the dispute was created in Chargehound.                                       |
 | updated              | string     | ISO 8601 timestamp - when the dispute was last updated in Chargehound.                                  |
-| source               | string     | The source of the dispute. One of `mock`, `api`, `braintree`, `vantiv`, `adyen`, `worldpay` or `stripe` |
-| processor            | string     | The payment processor of the dispute. One of `braintree`, `vantiv`, `adyen`, `worldpay` or `stripe`     |
+| source               | string     | The source of the dispute. One of `mock`, `api`, `braintree`, `vantiv`, `adyen`, `worldpay`, `paypal`, `amex` or `stripe` |
+| processor            | string     | The payment processor of the dispute. One of `braintree`, `vantiv`, `adyen`, `worldpay`, `paypal`, `amex` or `stripe`     |
 | kind                 | string     | The kind of the dispute. One of `chargeback`, `pre_arbitration` or `retrieval`                          |
 | account              | string     | The Id of the connected account for this dispute.                                                       |
 | reference_url        | string     | Custom URL with dispute information, such as the dispute or charge in your company dashboard.           |

--- a/source/includes/_integration.md
+++ b/source/includes/_integration.md
@@ -391,7 +391,7 @@ Chargehound chargehound = new Chargehound("{{your_chargehound_test_key}}");
 chargehound.disputes.submit("{{dispute_from_step_3}}");
 ```
 
-Because Chargehound creates live mode disputes with [webhooks](https://stripe.com/docs/webhooks) from Stripe, testing end to end requires creating a dispute in Stripe. You can do this by creating a charge with a [test card that simulates a dispute](https://stripe.com/docs/testing#how-do-i-test-disputes). You can create a charge with a [simple curl request](https://stripe.com/docs/api#create_charge), or via the [Stripe dashboard](https://support.stripe.com/questions/how-do-i-create-a-charge-via-the-dashboard).
+Because Chargehound creates live mode disputes with [webhooks](https://stripe.com/docs/webhooks) from Stripe, testing end to end requires creating a dispute in Stripe. You can do this by creating a charge with a [test card that simulates a dispute](https://stripe.com/docs/testing#how-do-i-test-disputes). If you have a test environment, you can create a charge there to simulate a dispute end to end in your system. You can also create a charge with a [simple curl request](https://stripe.com/docs/api#create_charge), or via the [Stripe dashboard](https://support.stripe.com/questions/how-do-i-create-a-charge-via-the-dashboard).
 
 ## Testing with Braintree
 
@@ -525,7 +525,7 @@ chargehound.disputes.submit("{{dispute_from_step_1}}");
 
 If you have a Braintree sandbox, you can test your integration using Chargehound's test mode and Braintree's sandox environment. First, you'll need to connect your Braintree sandbox to Chargehound, just as you did for your production Braintree environment. You can connect a Braintree sandbox account from the settings page [here](https://www.chargehound.com/dashboard/settings/processors).
 
-Because Chargehound creates live mode disputes with [webhooks](https://developers.braintreepayments.com/guides/webhooks/overview) from Braintree, testing end to end requires creating a dispute in Braintree. You can do this by creating a transaction with a [test card number that triggers a dispute](https://developers.braintreepayments.com/reference/general/testing#creating-a-disputed-test-transaction). You can create a transaction using [one of the Braintree SDKs](https://developers.braintreepayments.com/reference/request/transaction/sale), or via the [Braintree dashboard](https://articles.braintreepayments.com/control-panel/transactions/create).
+Because Chargehound creates live mode disputes with [webhooks](https://developers.braintreepayments.com/guides/webhooks/overview) from Braintree, testing end to end requires creating a dispute in Braintree. You can do this by creating a transaction with a [test card number that triggers a dispute](https://developers.braintreepayments.com/reference/general/testing#creating-a-disputed-test-transaction). If you have a test environment, you can create a transaction there to simulate a dispute end to end in your system. You can also create a transaction using [one of the Braintree SDKs](https://developers.braintreepayments.com/reference/request/transaction/sale), or via the [Braintree dashboard](https://articles.braintreepayments.com/control-panel/transactions/create).
 
 ## Testing with PayPal
 
@@ -619,7 +619,7 @@ chargehound.disputes.submit("{{dispute_from_step_1}}");
 
 If you have a PayPal sandbox account, you can test your integration using Chargehound's test mode and PayPal's sandox environment. First, you'll need to connect your PayPal sandbox to Chargehound, just as you did for your production PayPal environment. You can connect a PayPal sandbox account from the settings page [here](https://www.chargehound.com/dashboard/settings/processors).
 
-Testing end to end requires creating a dispute in PayPal. You can do this by creating a transaction from a sandbox PayPal [buyer account](https://developer.paypal.com/docs/classic/lifecycle/sb_about-accounts/) and disputing the transaction.
+Testing end to end requires creating a dispute in PayPal. You can do this by creating a transaction from a sandbox PayPal [buyer account](https://developer.paypal.com/docs/classic/lifecycle/sb_about-accounts/) and disputing the transaction. If you have a test environment, you can create a transaction there to simulate a dispute end to end in your system.
 
 ## Responding to your backlog
 


### PR DESCRIPTION
Document American Express

This just involves adding `amex` to our enums for now.

I also made testing instructions more explicit: https://github.com/chargehound/chargehound-slate/pull/62/commits/c648bfc1cf0eaa8cf8857c6f72cf4aa9c397f53f

In retrospect, those changes weren't a good fit for this branch, but they are here now.