### PR TITLE
Document metadata fields and test webhook

### DIFF
--- a/source/includes/_overview.md
+++ b/source/includes/_overview.md
@@ -205,6 +205,15 @@ try {
 
 When using our client libraries Chargehound also provides typed exceptions when errors are returned from the API.
 
+## Response metadata
+
+Our API responses contain a few standard metadata fields in the JSON. These fields are "object", "livemode", and "url". 
+
+"object" identifies the type of object returned by the API. Currently the object can be a ["dispute"](#the-dispute-object), "list", or ["webhook"](#webhooks). A list contains a list of other objects in the "data" field.
+
+"livemode" shows whether the API returned test or live data. The mode is determined by which API key was used to [authenticate](#authentication).
+
+"url" shows the path of the request that was made.
 
 ## Libraries
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -20,6 +20,29 @@ If you need to allowlist individual IP addresses in your firewall you can opt to
 
 To acknowledge successful receipt of a webhook, your endpoint should return a `2xx` HTTP status code. Any other information returned in the request headers or request body is ignored. All response codes outside this range, including `3xx` codes, will be treated as a failure. If a webhook is not successfully received for any reason, Chargehound will continue trying to send the webhook once every half hour for up to 3 days.
 
+## Test webhook
+
+A test webhook can be triggered from your [settings page](https://www.chargehound.com/dashboard/settings/api#webhook-settings) when adding or editing a webhook. The test webhook is intended to help you verify your webhook URL, test webhooks will only be sent when you trigger them. The test webhook "type" will always be "test", "livemode" will match the mode of the webhook, and the ID will be randomly generated.
+
+> Example request:
+
+```json
+{
+  "id": "wh_123",
+  "type": "test",
+  "object": "webhook",
+  "livemode": true
+}
+```
+
+The test webhook object is:
+
+| Field | Type | Description |
+|---------------------|---------|-----------|
+| id | string | A unique identifier for the webhook request. |
+| type | string | The event type. |
+| livemode | boolean | Is this a test or live mode webhook. |
+
 ## Dispute created
 
 Notification that Chargehound has received a new dispute from your payment processor.


### PR DESCRIPTION
Document the API metadata fields and the test webhook.

<img width="787" alt="Screen Shot 2020-10-21 at 12 00 20 PM" src="https://user-images.githubusercontent.com/1996632/96770847-bbfe6b80-1395-11eb-95ec-d09105766e17.png">

<img width="782" alt="Screen Shot 2020-10-21 at 12 04 00 PM" src="https://user-images.githubusercontent.com/1996632/96770859-c02a8900-1395-11eb-939a-5e2a823baf17.png">
