### PR TITLE
Update to v2.10.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6, 2.7]
+        ruby-version: [2.5, 2.6, 2.7, 3.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## Version 2.10.0
+
+*April 13, 2021*
+
+* Add support for Ruby 3.0 (thanks @shaun-scale)
+* Add requirement for Git on installing dependencies
+* Bump nokogiri from 1.11.2 to 1.11.3
+* Bump middleman from 4.3.11 to [`d180ca3`](https://github.com/middleman/middleman/commit/d180ca337202873f2601310c74ba2b6b4cf063ec)
+
+## Version 2.9.2
+
+*March 30, 2021*
+
+* __[Security]__ Bump kramdown from 2.3.0 to 2.3.1
+* Bump nokogiri from 1.11.1 to 1.11.2
+
+## Version 2.9.1
+
+*February 27, 2021*
+
+* Fix Slate language tabs not working if localStorage is disabled
+
 ## Version 2.9.0
 
 *January 19, 2021*

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ COPY Gemfile.lock .
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
+        git \
         nodejs \
     && gem install bundler \
     && bundle install \
-    && apt-get remove -y build-essential \
+    && apt-get remove -y build-essential git \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
-ruby '~> 2.5'
+ruby '>= 2.5'
 source 'https://rubygems.org'
 
 # Middleman
-gem 'middleman', '~>4.3'
+gem 'middleman', :github => 'middleman/middleman', :branch => '4.x'
 gem 'middleman-syntax', '~> 3.2'
 gem 'middleman-autoprefixer', '~> 2.7'
 gem 'middleman-sprockets', '~> 4.1'
@@ -10,3 +10,4 @@ gem 'rouge', '~> 3.21'
 gem 'redcarpet', '~> 3.5.0'
 gem 'nokogiri', '~> 1.11.0'
 gem 'sass'
+gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,58 +1,21 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/middleman/middleman.git
+  revision: d180ca337202873f2601310c74ba2b6b4cf063ec
+  branch: 4.x
   specs:
-    activesupport (5.2.4.4)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    autoprefixer-rails (9.5.1.1)
-      execjs
-    backports (3.18.2)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.7)
-    contracts (0.13.0)
-    dotenv (2.7.6)
-    erubis (2.7.0)
-    execjs (2.7.0)
-    fast_blank (1.0.0)
-    fastimage (2.2.0)
-    ffi (1.13.1)
-    haml (5.1.2)
-      temple (>= 0.8.0)
-      tilt
-    hamster (3.0.0)
-      concurrent-ruby (~> 1.0)
-    hashie (3.6.0)
-    i18n (0.9.5)
-      concurrent-ruby (~> 1.0)
-    kramdown (2.3.0)
-      rexml
-    listen (3.0.8)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    memoist (0.16.2)
     middleman (4.3.11)
       coffee-script (~> 2.2)
       haml (>= 4.0.5)
       kramdown (>= 2.3.0)
       middleman-cli (= 4.3.11)
       middleman-core (= 4.3.11)
-    middleman-autoprefixer (2.10.1)
-      autoprefixer-rails (~> 9.1)
-      middleman-core (>= 3.3.3)
     middleman-cli (4.3.11)
       thor (>= 0.17.0, < 2.0)
     middleman-core (4.3.11)
-      activesupport (>= 4.2, < 6.0)
+      activesupport (>= 4.2, < 6.1)
       addressable (~> 2.3)
       backports (~> 3.6)
-      bundler
+      bundler (~> 2.0)
       contracts (~> 0.13.0)
       dotenv
       erubis
@@ -70,7 +33,53 @@ GEM
       sassc (~> 2.0)
       servolux
       tilt (~> 2.0.9)
+      toml
       uglifier (~> 3.0)
+      webrick
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.3.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    autoprefixer-rails (9.5.1.1)
+      execjs
+    backports (3.21.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
+    concurrent-ruby (1.1.8)
+    contracts (0.13.0)
+    dotenv (2.7.6)
+    erubis (2.7.0)
+    execjs (2.7.0)
+    fast_blank (1.0.0)
+    fastimage (2.2.3)
+    ffi (1.15.0)
+    haml (5.2.1)
+      temple (>= 0.8.0)
+      tilt
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    hashie (3.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    kramdown (2.3.1)
+      rexml
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    memoist (0.16.2)
+    middleman-autoprefixer (2.10.1)
+      autoprefixer-rails (~> 9.1)
+      middleman-core (>= 3.3.3)
     middleman-sprockets (4.1.1)
       middleman-core (~> 4.0)
       sprockets (>= 3.0)
@@ -78,8 +87,8 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 3.2)
     mini_portile2 (2.5.0)
-    minitest (5.14.2)
-    nokogiri (1.11.1)
+    minitest (5.14.4)
+    nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     padrino-helpers (0.13.3.4)
@@ -88,7 +97,8 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
-    parallel (1.19.2)
+    parallel (1.20.1)
+    parslet (1.8.2)
     public_suffix (4.0.6)
     racc (1.5.2)
     rack (2.2.3)
@@ -96,7 +106,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rouge (3.26.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -110,19 +120,23 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     temple (0.8.2)
-    thor (1.0.1)
+    thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.7)
+    toml (0.2.0)
+      parslet (~> 1.8.0)
+    tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    webrick (1.7.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman (~> 4.3)
+  middleman!
   middleman-autoprefixer (~> 2.7)
   middleman-sprockets (~> 4.1)
   middleman-syntax (~> 3.2)
@@ -130,9 +144,10 @@ DEPENDENCIES
   redcarpet (~> 3.5.0)
   rouge (~> 3.21)
   sass
+  webrick
 
 RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.1.4
+   2.2.15

--- a/source/javascripts/app/_lang.js
+++ b/source/javascripts/app/_lang.js
@@ -129,11 +129,16 @@ under the License.
     history.pushState({}, '', '?' + generateNewQueryString(language) + '#' + hash);
 
     // save language as next default
-    localStorage.setItem("language", language);
+    if (localStorage) {
+      localStorage.setItem("language", language);
+    }
   }
 
   function setupLanguages(l) {
-    var defaultLanguage = localStorage.getItem("language");
+    var defaultLanguage = null;
+    if (localStorage) {
+      defaultLanguage = localStorage.getItem("language");
+    }
 
     languages = l;
 
@@ -142,7 +147,9 @@ under the License.
       // the language is in the URL, so use that language!
       activateLanguage(presetLanguage);
 
-      localStorage.setItem("language", presetLanguage);
+      if (localStorage) {
+        localStorage.setItem("language", presetLanguage);
+      }
     } else if ((defaultLanguage !== null) && (jQuery.inArray(defaultLanguage, languages) != -1)) {
       // the language was the last selected one saved in localstorage, so use that language!
       activateLanguage(defaultLanguage);


### PR DESCRIPTION
This will update the kramdom dependency for security: https://github.com/chargehound/chargehound-slate/compare/update_to_v2.10.0?expand=1#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR16