### PR TITLE
Upgraded the ruby version to fix the vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-slim
+FROM ruby:3.1.3-slim
 
 WORKDIR /srv/slate
 


### PR DESCRIPTION
The SAST tool (Snyk) has identified security risks with the base image of the chargehound-slate dockerfile.

The chargehound-slate dockerfile uses “ruby:2.6-slim” as their base image. However, this image introduces a lot of vulnerable libraries with critical/ high severity issues such as:

dpkg: currently utilizing 1.20.9, this version is vulnerable to directory traversal.

openssl/libssl1.1: currently utilizing 1.1.1n-0+deb11u1, this version is vulnerable to OS command injection.

libtasn1-6: currently utilizing 4.16.0-2, this version is vulnerable to a out-of-bounds read.

gzip: currently utilizing 1.10-4, this version is vulnerable to improper input validation.

zlib1g-dev: currently utilizing 1:1.2.11.dfsg-2+deb11u1, this version is vulnerable to out-of-bounds write.

pcre2/ libpcre2-8-0: currently utilizing 10.36-2, this version is vulnerable to an out-of-bounds read.

 

Requirements:

Upon review, we noted that this is a true positive - [Dockerfile](https://github.com/chargehound/chargehound-slate/blob/main/Dockerfile) . All these issues can be fixed by upgrading the base image to “ruby:3.1.3-slim”.

Refer: [DTFPCHG-111](https://paypal.atlassian.net/browse/DTFPCHG-111)