### PR TITLE
DTFPCHG-218 Fixed the vulnerabilities reported by Snyk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, '3.0', 3.1]
+        ruby-version: [2.7, '3.0', 3.1]
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '>= 2.6'
+ruby '>= 2.7'
 source 'https://rubygems.org'
 
 # Middleman
@@ -8,6 +8,6 @@ gem 'middleman-autoprefixer', '~> 3.0'
 gem 'middleman-sprockets', '~> 4.1'
 gem 'rouge', '~> 3.21'
 gem 'redcarpet', '~> 3.6.0'
-gem 'nokogiri', '~> 1.13.3'
+gem 'nokogiri', '~> 1.13.10'
 gem 'sass'
 gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.6.1)
+    activesupport (7.0.4.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -82,7 +82,7 @@ GEM
       rouge (~> 3.2)
     mini_portile2 (2.8.0)
     minitest (5.17.0)
-    nokogiri (1.13.9)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     padrino-helpers (0.15.2)
@@ -94,7 +94,7 @@ GEM
     parslet (2.0.0)
     public_suffix (5.0.1)
     racc (1.6.0)
-    rack (2.2.6.2)
+    rack (3.0.8)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -132,7 +132,7 @@ DEPENDENCIES
   middleman-autoprefixer (~> 3.0)
   middleman-sprockets (~> 4.1)
   middleman-syntax (~> 3.2)
-  nokogiri (~> 1.13.3)
+  nokogiri (~> 1.13.10)
   redcarpet (~> 3.6.0)
   rouge (~> 3.21)
   sass


### PR DESCRIPTION
DTFPCHG-218 Fixed the vulnerabilities reported by Snaky

## JIRA ID | Git Issue #
*[DTFPCHG-218](https://paypal.atlassian.net/browse/DTFPCHG-218)*

## Change Type
- [X] Bug fix (is this a backward compatible change?)
- [ ] New feature (is this a backward compatible change?)
- [ ] Breaking change (is this a non-backward compatible change?)
- [ ] DB changes (add scripts in the sql/migrations/{date} folder)

## Change Impact
####  Summary
Snyk has reported the following vulnerabilities,

zlib: upgrade to version 1:1.2.11.dfsg-2+deb11u2
dpkg: upgrade to version 1.20.10
activesupport: introduced through middleman, currently utilizes 6.1.6.1, upgrade to 7.0.4.3
nokogiri: currently utilizing 1.13.9, upgrade to 1.13.10-aarch64-linux
rack: introduced through middleman, currently utilizes 2.2.6.2, upgrade to 3.4.2
openssl: upgrade to version 1.1.1n-0+deb11u4 or higher
pcre2: upgrade to version 10.36-2+deb11u1
libtasn1-6: upgrade to version 4.16.0-2+deb11u1

### Demo
![image](https://github.com/chargehound/chargehound-slate/assets/120496064/5f25a5c6-b2a7-4693-9b02-54c814ade4b1)

### Notes
Upgraded the reported vulnerable packages and ensured that the build is successful. 
Also tested out the scenarios related to documentation for which we are using this repo as a sub-module to charge hound-api. 
 
## Testing Instructions

 * After upgrading the vulnerable packages, ensure that the build is successful by executing the bundle install. 
 * Now apply these changes in the locally running environment.
 * Ensure that while building the images bundle install gets executed for api_docs image which is built as a sub-module to charge hound-api. 
 * Now try to access the documentation links from the UI and verify all the components are getting displayed as expected.
