### PR TITLE
FIX [DTFPCHG-1533] Render API Docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [3.0, 3.1]
+        ruby-version: [3.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -53,7 +53,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      ruby-version: 2.6
+      ruby-version: 3.2
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+
+## Version 2.14.0
+
+*January 16, 2025*
+
+* Updated ruby version from 3.1.6 to 3.2.2
+* Updated bundler version from 2.2.22 to 2.6.2
+* Fix date format in HTML files.
+* Updated Github workflows to use bumped ruby version.
+
 ## Version 2.13.1
 
 *January 31, 2023*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.3-slim
+FROM ruby:3.2.2
 
 WORKDIR /srv/slate
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '>= 3.0'
+ruby '>= 3.2'
 source 'https://rubygems.org'
 
 # Middleman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4.3)
+    activesupport (7.0.8.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (10.2.5.0)
@@ -94,7 +93,7 @@ GEM
     parslet (2.0.0)
     public_suffix (5.0.1)
     racc (1.6.0)
-    rack (3.0.8)
+    rack (2.2.10)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -122,7 +121,6 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     webrick (1.8.1)
-    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby
@@ -139,7 +137,7 @@ DEPENDENCIES
   webrick
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.2.2p53
 
 BUNDLED WITH
-   2.2.22
+   2.6.2

--- a/source/2016-03-05/index.html.md
+++ b/source/2016-03-05/index.html.md
@@ -21,6 +21,6 @@ includes:
 
 search: false
 
-version: 2016-03-05
+version: "2016-03-05"
 
 ---

--- a/source/2017-10-30/index.html.md
+++ b/source/2017-10-30/index.html.md
@@ -21,6 +21,6 @@ includes:
 
 search: false
 
-version: 2017-10-30
+version: "2017-10-30"
 
 ---

--- a/source/2020-02-28/index.html.md
+++ b/source/2020-02-28/index.html.md
@@ -21,6 +21,6 @@ includes:
 
 search: false
 
-version: 2020-02-28
+version: "2020-02-28"
 
 ---

--- a/source/2021-09-15/index.html.md
+++ b/source/2021-09-15/index.html.md
@@ -21,6 +21,6 @@ includes:
 
 search: false
 
-version: 2021-09-15
+version: "2021-09-15"
 
 ---


### PR DESCRIPTION
Updated Ruby version to 3.1.

Issue:
YAML Parser was parsing date as a date object instead of a string.

![image](https://github.com/user-attachments/assets/be3ebfdb-ba27-4b8e-b68a-90eef971c867)


Solution:
Wrap date in quotes.

Demo:
![Screenshot 2025-01-16 at 5 54 18 PM](https://github.com/user-attachments/assets/71f7c156-c6bf-448f-aaf8-afcf2ddf4afe)
